### PR TITLE
fix: correct silent bugs across layout, projects, about, and tailwind

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,6 +3,7 @@ import BackgroundShape from "@/components/BackgroundShape";
 import { AcademicCapIcon, CodeBracketIcon, LightBulbIcon } from "@heroicons/react/24/outline";
 
 import ImageCarousel from "@/components/ImageCarousel";
+import Link from "next/link";
 import { Metadata } from "next";
 import { getPlaiceholder } from "plaiceholder";
 import path from "path";
@@ -85,7 +86,7 @@ export default async function AboutPage() {
                         Hi, I&apos;m Andrea Venti
                     </h1>
                     <p className="mt-6 text-lg leading-8" data-aos="fade-up">
-                        I’m a Computer Science student at the{" "}
+                        I’m a Computer Science graduate from the{" "}
                         <span className="font-bold">University of Miami</span> with a passion for
                         building systems that are not just functional, but reliable, secure, and
                         maintainable. My background blends{" "}
@@ -199,12 +200,12 @@ export default async function AboutPage() {
                             Always eager to connect with like-minded professionals and explore new
                             opportunities. Let’s work together to bring innovative ideas to life!
                         </p>
-                        <a
+                        <Link
                             href="/contact"
                             className="mt-6 inline-block rounded-md bg-white bg-opacity-80 px-6 py-3 text-sm font-semibold text-indigo-700 hover:bg-opacity-100 transform hover:scale-105 transition duration-300"
                         >
                             Get in Touch
-                        </a>
+                        </Link>
                     </div>
                 </div>
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -92,14 +92,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     return (
         <html lang="en" className={`${inter.className} antialiased`}>
             <head>
-                {/* Link to Web App Manifest */}
-                <link rel="manifest" href="/site.webmanifest" />
-
                 {/* Prefetch resume PDF */}
                 <link rel="prefetch" href="/sre-resume.pdf" as="fetch" type="application/pdf" />
-
-                {/* Additional icons */}
-                <link rel="apple-touch-icon" href="/favicon.png" />
             </head>
             <body className="font-sans antialiased bg-gradient-to-r from-indigo-700 via-purple-700 to-pink-700 bg-size-130">
                 <Header />

--- a/src/app/projects/ProjectsPageClient.tsx
+++ b/src/app/projects/ProjectsPageClient.tsx
@@ -99,7 +99,7 @@ export default function ProjectsPageClient({ projectsWithBlurData }: ProjectsPag
                     {/* Projects Grid */}
                     <div className="mt-10 sm:mt-14 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-12">
                         {filteredProjects.map((project, index) => (
-                            <div key={project.title} data-aos="zoom-in">
+                            <div key={project.slug} data-aos="zoom-in">
                                 {/* Inner container for hover effects */}
                                 <div
                                     className="group relative bg-white bg-opacity-20 border border-white rounded-lg shadow-lg overflow-hidden hover:shadow-2xl transform hover:scale-105 transition duration-200 p-4 h-full flex flex-col hover:bg-white hover:bg-opacity-30 cursor-pointer"
@@ -121,7 +121,6 @@ export default function ProjectsPageClient({ projectsWithBlurData }: ProjectsPag
                                                 className="rounded-lg"
                                                 draggable={false}
                                                 priority={index < 6}
-                                                loading={index < 6 ? "eager" : "lazy"}
                                                 placeholder="blur"
                                                 blurDataURL={project.blurDataURL}
                                             />

--- a/src/components/projects/ProjectModal.tsx
+++ b/src/components/projects/ProjectModal.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
-import { Fragment } from "react";
+import React, { Fragment } from "react";
 
 interface ProjectModalProps {
     selectedProject: Project | null;
@@ -80,7 +80,6 @@ const ProjectModal: React.FC<ProjectModalProps> = ({ selectedProject, closeProje
                                             className="rounded-lg"
                                             draggable={false}
                                             priority={true}
-                                            loading="eager"
                                             placeholder="blur"
                                             blurDataURL={selectedProject.blurDataURL}
                                         />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,7 +45,7 @@ const config: Config = {
                 "marquee-sm": "marquee 30s linear infinite", // smartphone screen
                 "marquee-md": "marquee 45s linear infinite", // medium screen
                 "marquee-lg": "marquee 70s linear infinite", // wide screen
-                gradientMove: "gradientMove 10s ease infinite",
+                "gradient-move": "gradient-move 10s ease infinite",
             },
             // Keyframes for custom animations
             // Documentation: https://tailwindcss.com/docs/animation#customizing-keyframes
@@ -54,7 +54,7 @@ const config: Config = {
                     "0%": { transform: "translateX(0%)" },
                     "100%": { transform: "translateX(-100%)" },
                 },
-                gradientMove: {
+                "gradient-move": {
                     "0%": { backgroundPosition: "0% 50%" },
                     "50%": { backgroundPosition: "100% 50%" },
                     "100%": { backgroundPosition: "0% 50%" },


### PR DESCRIPTION
## Summary

- **`layout.tsx`**: Removes duplicate `<link rel="manifest">` and `<link rel="apple-touch-icon">` tags from the JSX `<head>` — both were already being emitted automatically by `metadata.manifest` and `metadata.icons.apple`, causing them to appear twice in rendered HTML.
- **`ProjectModal.tsx`**: Adds missing `React` import (`React.FC` references `React` as a value-level type — without the import TypeScript errors at compile time). Removes redundant `loading="eager"` alongside `priority={true}`.
- **`ProjectsPageClient.tsx`**: Fixes `key={project.title}` → `key={project.slug}` to use the guaranteed-unique identifier, preventing React reconciliation bugs if two projects share a title. Removes redundant `loading` prop alongside `priority`.
- **`tailwind.config.ts`**: Renames animation and keyframe key from camelCase `gradientMove` to kebab-case `"gradient-move"` — Tailwind generates `animate-gradientMove` from camelCase keys, but the code uses `animate-gradient-move` (and the safelist has `animate-gradient-move`). The gradient animation on the projects page hero was silently broken and never running.
- **`about/page.tsx`**: Corrects bio text from "Computer Science student at the University of Miami" to "graduate from the University of Miami". Replaces `<a href="/contact">` with `<Link href="/contact">` for proper Next.js client-side navigation.

## Testing

- `pnpm build` passes clean (10 routes, 0 errors).
- CI must pass before merge.