### PR TITLE
fix(cleanup): remove dead React imports, fix invalid Tailwind class, remove console.log

### DIFF
--- a/src/app/resume/ResumePageClient.tsx
+++ b/src/app/resume/ResumePageClient.tsx
@@ -28,13 +28,13 @@ export default function ResumePageClient() {
                             href="/sre-resume.pdf"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="rounded-md bg-white bg-opacity-80 px-4 py-2 text-md font-semibold text-indigo-700 hover:bg-opacity-100 transform hover:scale-105 transition duration-300 flex items-center justify-center w-36"
+                            className="rounded-md bg-white bg-opacity-80 px-4 py-2 text-base font-semibold text-indigo-700 hover:bg-opacity-100 transform hover:scale-105 transition duration-300 flex items-center justify-center w-36"
                         >
                             <ArrowDownTrayIcon className="h-5 w-5 mr-2" />
                             Download
                         </a>
                         <button
-                            className="rounded-md bg-white bg-opacity-80 px-4 py-2 text-md font-semibold text-indigo-700 hover:bg-opacity-100 transform hover:scale-105 transition duration-300 flex items-center justify-center w-36"
+                            className="rounded-md bg-white bg-opacity-80 px-4 py-2 text-base font-semibold text-indigo-700 hover:bg-opacity-100 transform hover:scale-105 transition duration-300 flex items-center justify-center w-36"
                             onClick={() => {
                                 if (navigator.share) {
                                     navigator
@@ -43,7 +43,6 @@ export default function ResumePageClient() {
                                             text: "Check out Andrea Venti Fuentes' professional resume. View or download it here.",
                                             url: window.location.href,
                                         })
-                                        .then(() => console.log("Shared successfully!"))
                                         .catch((error) => console.error("Error sharing:", error));
                                 } else {
                                     alert("Your browser does not support the Share feature.");

--- a/src/components/BackgroundShape.tsx
+++ b/src/components/BackgroundShape.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 interface BackgroundShapeProps {
     clipPath?: string;
     gradientFrom?: string;
@@ -10,7 +8,7 @@ interface BackgroundShapeProps {
     opacity?: string;
 }
 
-const BackgroundShape: React.FC<BackgroundShapeProps> = ({
+const BackgroundShape = ({
     clipPath = "polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)",
     gradientFrom = "from-pink-500",
     gradientTo = "to-indigo-500",
@@ -18,7 +16,7 @@ const BackgroundShape: React.FC<BackgroundShapeProps> = ({
     positionClasses = "left-[calc(50%-11rem)] sm:left-[calc(50%-30rem)]",
     rotationClasses = "rotate-[30deg]",
     opacity = "opacity-70",
-}) => {
+}: BackgroundShapeProps) => {
     return (
         <div className="absolute inset-0">
             <div

--- a/src/components/projects/CategoryFilter.tsx
+++ b/src/components/projects/CategoryFilter.tsx
@@ -1,17 +1,15 @@
-import React from "react";
-
 interface CategoryFilterProps {
     activeCategory: "All" | "Projects" | "Programs";
     setActiveCategory: (category: "All" | "Projects" | "Programs") => void;
 }
 
-const CategoryFilter: React.FC<CategoryFilterProps> = ({ activeCategory, setActiveCategory }) => {
+const CategoryFilter = ({ activeCategory, setActiveCategory }: CategoryFilterProps) => {
     return (
         <div className="flex justify-center space-x-4" data-aos="fade-up">
             {["All", "Projects", "Programs"].map((category) => (
                 <button
                     key={category}
-                    className={`px-4 py-2 rounded-md text-sm font-medium transition duration-200 transform shadow-md  ${
+                    className={`px-4 py-2 rounded-md text-sm font-medium transition duration-200 transform shadow-md ${
                         activeCategory === category
                             ? "bg-white bg-opacity-80 text-indigo-700"
                             : "bg-white bg-opacity-20 text-white hover:text-indigo-700"

--- a/src/components/projects/LanguageFilter.tsx
+++ b/src/components/projects/LanguageFilter.tsx
@@ -1,13 +1,13 @@
 import { Menu, MenuButton, MenuItem, MenuItems, Transition } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 
 interface LanguageFilterProps {
     activeLanguage: string;
     setActiveLanguage: (language: string) => void;
 }
 
-const LanguageFilter: React.FC<LanguageFilterProps> = ({ activeLanguage, setActiveLanguage }) => {
+const LanguageFilter = ({ activeLanguage, setActiveLanguage }: LanguageFilterProps) => {
     const languages = [
         "Python",
         "Java",


### PR DESCRIPTION
## Summary

- **`BackgroundShape.tsx`, `CategoryFilter.tsx`, `LanguageFilter.tsx`**: Remove unnecessary `import React from 'react'`. The new JSX transform (default in Next.js 13+) injects the runtime automatically — the explicit import is dead code. Replace `React.FC<Props>` with modern explicit typed destructured params (`({ prop }: Props) =>`), which avoids the React namespace entirely.
- **`ResumePageClient.tsx`**: Replace invalid Tailwind class `text-md` (does not exist in Tailwind v3 — silently does nothing) with `text-base` (1rem/16px) on both the Download link and Share button. Remove `console.log("Shared successfully!")` from the production share handler.

## Behavior

No visual or functional changes. `text-base` produces the same rendered size that `text-md` was silently failing to produce.

## Testing

- `pnpm build` passes clean (10 routes, 0 errors).
- CI must pass before merge.