### PR TITLE
fix(accessibility): harden blur fallback and nav semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          standalone: true
-          # Reads version from the packageManager field in package.json
-          run_install: false
+      # Node 20 ships with Corepack; it will install the pnpm version declared
+      # in package.json's packageManager field when pnpm commands run.
+      - name: Enable Corepack
+        run: corepack enable pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
+          standalone: true
           # Reads version from the packageManager field in package.json
           run_install: false
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,29 @@
+const securityHeaders = [
+    {
+        key: "X-Content-Type-Options",
+        value: "nosniff",
+    },
+    {
+        key: "Referrer-Policy",
+        value: "strict-origin-when-cross-origin",
+    },
+    {
+        key: "Permissions-Policy",
+        value: "camera=(), microphone=(), geolocation=()",
+    },
+];
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    poweredByHeader: false,
+    async headers() {
+        return [
+            {
+                source: "/(.*)",
+                headers: securityHeaders,
+            },
+        ];
+    },
+};
 
 export default nextConfig;

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -41,8 +41,9 @@ export default function HomePageClient() {
                             href="https://github.com/av1155"
                             className="rounded-md bg-white px-5 py-3 text-base font-semibold text-indigo-600 hover:bg-gray-200 ease-in-out shadow-lg hover:bg-opacity-100 transform hover:scale-105 transition duration-300 inline-flex items-center"
                             target="_blank"
+                            rel="noopener noreferrer"
                         >
-                            <FontAwesomeIcon icon={faGithub} className="w-5 h-5 mr-2" />{" "}
+                            <FontAwesomeIcon icon={faGithub} className="w-5 h-5 mr-2" aria-hidden="true" />{" "}
                             {/* GitHub icon */}
                             Explore GitHub
                         </Link>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -61,12 +61,24 @@ export default async function AboutPage() {
     // Generate blurDataURL for each image
     const imagesWithBlurData = await Promise.all(
         images.map(async (image) => {
-            const buffer = await fs.readFile(path.join(process.cwd(), "public", image.src));
-            const { base64 } = await getPlaiceholder(buffer);
-            return {
-                ...image,
-                blurDataURL: base64,
-            };
+            try {
+                const imgPath = path.join(
+                    process.cwd(),
+                    "public",
+                    image.src.replace(/^\/+/, ""),
+                );
+                const buffer = await fs.readFile(imgPath);
+                const { base64 } = await getPlaiceholder(buffer);
+                return {
+                    ...image,
+                    blurDataURL: base64,
+                };
+            } catch {
+                return {
+                    ...image,
+                    blurDataURL: "",
+                };
+            }
         }),
     );
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -47,7 +47,10 @@ export default function Header() {
                 scrolled ? "bg-white shadow-md" : "bg-transparent"
             }`}
         >
-            <nav className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4 lg:px-8">
+            <nav
+                className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4 lg:px-8"
+                aria-label="Primary navigation"
+            >
                 {/* Logo Section */}
                 <Link
                     href="/"
@@ -107,6 +110,7 @@ export default function Header() {
                                       ? "text-gray-900 hover:text-indigo-600"
                                       : "text-gray-900 hover:text-indigo-800"
                             } transform hover:scale-105`}
+                            aria-current={isActive(href) ? "page" : undefined}
                         >
                             {name}
                         </Link>
@@ -153,7 +157,7 @@ export default function Header() {
                 </div>
 
                 {/* Mobile Navigation */}
-                <nav className="mt-6 space-y-2">
+                <nav className="mt-6 space-y-2" aria-label="Mobile navigation">
                     {navigation.map(({ name, href }) => (
                         <Link
                             key={name}
@@ -164,6 +168,7 @@ export default function Header() {
                                     : "text-gray-900 hover:bg-gray-50"
                             }`}
                             onClick={() => setMobileMenuOpen(false)}
+                            aria-current={isActive(href) ? "page" : undefined}
                         >
                             {name}
                         </Link>

--- a/src/components/projects/LanguageFilter.tsx
+++ b/src/components/projects/LanguageFilter.tsx
@@ -1,3 +1,4 @@
+import { projects } from "@/data/projectsData";
 import { Menu, MenuButton, MenuItem, MenuItems, Transition } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import { Fragment } from "react";
@@ -7,23 +8,11 @@ interface LanguageFilterProps {
     setActiveLanguage: (language: string) => void;
 }
 
-const LanguageFilter = ({ activeLanguage, setActiveLanguage }: LanguageFilterProps) => {
-    const languages = [
-        "Python",
-        "Java",
-        "JavaScript",
-        "TypeScript",
-        "Dart",
-        "Go",
-        "C",
-        "C++",
-        "Bash",
-        "Lua",
-        "Swift",
-        "YAML",
-        "Markdown",
-    ];
+const languages = Array.from(
+    new Set(projects.flatMap((project) => project.languages)),
+).sort((a, b) => a.localeCompare(b));
 
+const LanguageFilter = ({ activeLanguage, setActiveLanguage }: LanguageFilterProps) => {
     return (
         <div className="z-[60] relative flex justify-center md:ml-4 space-x-4" data-aos="fade-up">
             <Menu as="div" className="relative inline-block text-left">


### PR DESCRIPTION
## Summary
- guard about-page plaiceholder loading so missing images don\'t crash builds and sanitize paths
- tighten homepage and header accessibility (noopener, aria-current, labels) and derive language filters dynamically
- add lightweight security headers sitewide without blocking the resume iframe

## Testing
- ~/.nvm/versions/node/v24.14.0/bin/pnpm lint
- ~/.nvm/versions/node/v24.14.0/bin/pnpm build